### PR TITLE
Set match labels

### DIFF
--- a/helm/kubernetes-node-health-chart/templates/daemonset.yaml
+++ b/helm/kubernetes-node-health-chart/templates/daemonset.yaml
@@ -8,6 +8,9 @@ metadata:
 spec:
   updateStrategy:
     type: RollingUpdate
+  selector:
+    matchLabels:
+      app: kubernetes-node-health
   template:
     metadata:
       name: kubernetes-node-health


### PR DESCRIPTION
For the apps/v1 API version you have to set the match labels explicitly for daemonsets. I missed this earlier.